### PR TITLE
Add a wrapper for a discord message and discord source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,11 @@ dist
 
 # TernJS port file
 .tern-port
+/.idea/codeStyles/codeStyleConfig.xml
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/org-helper.iml
+/.idea/codeStyles/Project.xml
+/.idea/inspectionProfiles/Project_Default.xml
+/.idea/vcs.xml
+/.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Idea files
 /.idea/codeStyles/codeStyleConfig.xml
 /.idea/misc.xml
 /.idea/modules.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,16 @@
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
@@ -114,6 +124,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -248,6 +264,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "bson": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
@@ -348,6 +373,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -355,6 +386,60 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -385,6 +470,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true
     },
     "compare-versions": {
       "version": "3.6.0",
@@ -470,6 +561,12 @@
       "requires": {
         "ms": "^2.1.1"
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-equal": {
       "version": "2.0.3",
@@ -560,6 +657,15 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.5.tgz",
+      "integrity": "sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.2.1"
       }
     },
     "entities": {
@@ -1147,6 +1253,15 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -1212,6 +1327,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
       "dev": true
     },
     "get-stdin": {
@@ -1289,6 +1410,12 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
     "husky": {
@@ -1412,6 +1539,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -1567,10 +1700,22 @@
         "define-properties": "^1.1.3"
       }
     },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
     "is-number-object": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
       "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.5",
@@ -1579,6 +1724,12 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-set": {
       "version": "2.0.1",
@@ -1731,6 +1882,73 @@
         "uc.micro": "^1.0.1"
       }
     },
+    "lint-staged": {
+      "version": "10.2.11",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.2.11.tgz",
+      "integrity": "sha512-LRRrSogzbixYaZItE2APaS4l2eJMjjf5MbclRZpLJtcQJShcvUzKXsNeZgsLIZ0H0+fg2tL4B59fU9wHIHtFIA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "cli-truncate": "2.1.0",
+        "commander": "^5.1.0",
+        "cosmiconfig": "^6.0.0",
+        "debug": "^4.1.1",
+        "dedent": "^0.7.0",
+        "enquirer": "^2.3.5",
+        "execa": "^4.0.1",
+        "listr2": "^2.1.0",
+        "log-symbols": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "string-argv": "0.3.1",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        }
+      }
+    },
+    "listr2": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.1.8.tgz",
+      "integrity": "sha512-Op+hheiChfAphkJ5qUxZtHgyjlX9iNnAeFS/S134xw7mVSg0YVrQo1IY4/K+ElY6XgOPg2Ij4z07urUXR+YEew==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "cli-truncate": "^2.1.0",
+        "figures": "^3.2.0",
+        "indent-string": "^4.0.0",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rxjs": "^6.5.5",
+        "through": "^2.3.8"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -1769,6 +1987,71 @@
       "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0"
+      }
+    },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        }
+      }
     },
     "long-timeout": {
       "version": "0.1.1",
@@ -1813,6 +2096,16 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      }
     },
     "mime-db": {
       "version": "1.43.0",
@@ -1949,6 +2242,12 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
@@ -2068,6 +2367,15 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -2124,6 +2432,12 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -2578,6 +2892,12 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-similarity": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.1.tgz",
@@ -2645,6 +2965,17 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -2758,6 +3089,15 @@
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "tslib": {
@@ -2882,6 +3222,44 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "eslint-plugin-unicorn": "^20.1.0",
     "husky": "^4.2.5",
+    "lint-staged": "^10.2.11",
     "prettier": "2.0.5",
     "pretty-quick": "^2.0.1"
   },

--- a/src/arg_scanners/discord-time-arg-scanner.js
+++ b/src/arg_scanners/discord-time-arg-scanner.js
@@ -10,7 +10,6 @@ const TimeArgScanner = require('./time-arg-scanner');
 
 const TimeArg = require('../command_meta/time-arg');
 
-const BotTable = require('../mongo_classes/bot-table');
 const ServerSettingsTable = require('../mongo_classes/server-settings-table');
 const UserSettingsTable = require('../mongo_classes/user-settings-table');
 

--- a/src/arg_scanners/discord-time-arg-scanner.js
+++ b/src/arg_scanners/discord-time-arg-scanner.js
@@ -27,7 +27,7 @@ class DiscordTimeArgScanner extends TimeArgScanner {
    * Appends a timezone definition to a TimeArg, based on organization's or individual preference for the timezone.
    * @see TimeArg
    * @param  {Context}      context     the Bot's context
-   * @param  {Message}      message     the Discord message with the argument
+   * @param  {BaseMessage}      message     the Discord message with the argument
    * @param  {TimeArg}      timeArg     the time argument to edit
    * @return {Promise}                  nothing
    */
@@ -38,14 +38,14 @@ class DiscordTimeArgScanner extends TimeArgScanner {
 
     const serverTimezone = await context.dbManager.getSetting(
       BotTable.DISCORD_SOURCE,
-      message.guild.id,
+      message.teamId,
       ServerSettingsTable.SERVER_SETTINGS.timezone.name
     );
 
     const userTimezone = await context.dbManager.getUserSetting(
       BotTable.DISCORD_SOURCE,
-      message.guild.id,
-      message.member.id,
+      message.teamId,
+      message.originalMessage.member.id,
       UserSettingsTable.USER_SETTINGS.timezone.name
     );
 

--- a/src/arg_scanners/discord-time-arg-scanner.js
+++ b/src/arg_scanners/discord-time-arg-scanner.js
@@ -37,13 +37,13 @@ class DiscordTimeArgScanner extends TimeArgScanner {
     }
 
     const serverTimezone = await context.dbManager.getSetting(
-      BotTable.DISCORD_SOURCE,
+      message.source.name,
       message.teamId,
       ServerSettingsTable.SERVER_SETTINGS.timezone.name
     );
 
     const userTimezone = await context.dbManager.getUserSetting(
-      BotTable.DISCORD_SOURCE,
+      message.source.name,
       message.teamId,
       message.originalMessage.member.id,
       UserSettingsTable.USER_SETTINGS.timezone.name

--- a/src/arg_scanners/discord-time-arg-scanner.js
+++ b/src/arg_scanners/discord-time-arg-scanner.js
@@ -26,7 +26,7 @@ class DiscordTimeArgScanner extends TimeArgScanner {
    * Appends a timezone definition to a TimeArg, based on organization's or individual preference for the timezone.
    * @see TimeArg
    * @param  {Context}      context     the Bot's context
-   * @param  {BaseMessage}      message     the Discord message with the argument
+   * @param  {BaseMessage}  message     the Discord message with the argument
    * @param  {TimeArg}      timeArg     the time argument to edit
    * @return {Promise}                  nothing
    */
@@ -37,14 +37,14 @@ class DiscordTimeArgScanner extends TimeArgScanner {
 
     const serverTimezone = await context.dbManager.getSetting(
       message.source.name,
-      message.teamId,
+      message.orgId,
       ServerSettingsTable.SERVER_SETTINGS.timezone.name
     );
 
     const userTimezone = await context.dbManager.getUserSetting(
       message.source.name,
-      message.teamId,
-      message.originalMessage.member.id,
+      message.orgId,
+      message.userId,
       UserSettingsTable.USER_SETTINGS.timezone.name
     );
 

--- a/src/arg_scanners/time-arg-scanner.js
+++ b/src/arg_scanners/time-arg-scanner.js
@@ -93,7 +93,7 @@ class TimeArgScanner extends SimpleArgScanner {
    * Appends a timezone definition to a TimeArg, based on organization's or individual preference for the timezone.
    * @see TimeArg
    * @param  {Context}      context     the Bot's context
-   * @param  {BaseMessage}      message     the Discord message with the argument
+   * @param  {BaseMessage}  message     the Discord message with the argument
    * @param  {TimeArg}      timeArg     the time argument to edit
    * @return {Promise}                  nothing
    */

--- a/src/arg_scanners/time-arg-scanner.js
+++ b/src/arg_scanners/time-arg-scanner.js
@@ -93,7 +93,7 @@ class TimeArgScanner extends SimpleArgScanner {
    * Appends a timezone definition to a TimeArg, based on organization's or individual preference for the timezone.
    * @see TimeArg
    * @param  {Context}      context     the Bot's context
-   * @param  {Message}      message     the Discord message with the argument
+   * @param  {BaseMessage}      message     the Discord message with the argument
    * @param  {TimeArg}      timeArg     the time argument to edit
    * @return {Promise}                  nothing
    */

--- a/src/commands_discord/discord-command.js
+++ b/src/commands_discord/discord-command.js
@@ -47,7 +47,7 @@ class DiscordCommand extends Command {
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
    * @param  {Context}        context the Bot's context
-   * @param  {BaseMessage}        message the command's message
+   * @param  {BaseMessage}    message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -141,31 +141,29 @@ class DiscordCommand extends Command {
     for (const argKey of argsKeys) {
       const argText = this.findArgValue(message.content, definedArgs[argKey]);
       results.push(
-        definedArgs[argKey].scanner
-          .scan(this.context, this.langManager, message, argText)
-          .then(async scanResult => {
-            let argValue = scanResult.value;
-            thiz.context.log.d(
-              'argValue: ' + util.inspect(argValue, { showHidden: false, depth: 2 }) + '; for key: ' + argKey
+        definedArgs[argKey].scanner.scan(this.context, this.langManager, message, argText).then(async scanResult => {
+          let argValue = scanResult.value;
+          thiz.context.log.d(
+            'argValue: ' + util.inspect(argValue, { showHidden: false, depth: 2 }) + '; for key: ' + argKey
+          );
+          if (argValue === null || argValue === undefined) {
+            scanResult = await definedArgs[argKey].scanner.scan(
+              thiz.context,
+              thiz.langManager,
+              message,
+              thiz.getDefaultDiscordArgValue(message, definedArgs[argKey])
             );
-            if (argValue === null || argValue === undefined) {
-              scanResult = await definedArgs[argKey].scanner.scan(
-                thiz.context,
-                thiz.langManager,
-                message,
-                thiz.getDefaultDiscordArgValue(message, definedArgs[argKey])
-              );
-              argValue = scanResult.value;
-              thiz.context.log.d(
-                'argValue after checking default: ' +
-                  util.inspect(argValue, { showHidden: false, depth: 2 }) +
-                  '; for key: ' +
-                  argKey
-              );
-            }
+            argValue = scanResult.value;
+            thiz.context.log.d(
+              'argValue after checking default: ' +
+                util.inspect(argValue, { showHidden: false, depth: 2 }) +
+                '; for key: ' +
+                argKey
+            );
+          }
 
-            thiz[argKey] = argValue;
-          })
+          thiz[argKey] = argValue;
+        })
       );
     }
 
@@ -284,7 +282,7 @@ class DiscordCommand extends Command {
       await this.parseFromDiscordSequentially(message);
     } else {
       this.context.log.d('Arg scan by name');
-      await this.parseFromDiscordByNames( message);
+      await this.parseFromDiscordByNames(message);
     }
 
     await this.validateFromDiscord(message);

--- a/src/commands_discord/discord-command.js
+++ b/src/commands_discord/discord-command.js
@@ -47,7 +47,7 @@ class DiscordCommand extends Command {
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
    * @param  {Context}        context the Bot's context
-   * @param  {Message}        message the command's message
+   * @param  {BaseMessage}        message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -62,10 +62,10 @@ class DiscordCommand extends Command {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
+  async validateFromDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     await ArgValidationTree.validateCommandArguments(this);
@@ -75,10 +75,10 @@ class DiscordCommand extends Command {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     throw new Error('executeForDiscord: ' + this.constructor.name + ' is an abstract class.');
@@ -130,20 +130,20 @@ class DiscordCommand extends Command {
    * @see DiscordCommand#findArgValue
    * @see Command.getDefinedArgs
    * @param  {Client}   client         the Discord client
-   * @param  {Message}  discordMessage the Discord message with the command
+   * @param  {BaseMessage}  message the Discord message with the command
    * @return {Promise}                 nothing
    */
-  async parseFromDiscordByNames(client, discordMessage) {
+  async parseFromDiscordByNames(client, message) {
     const definedArgs = this.constructor.getDefinedArgs();
     const argsKeys = Object.keys(definedArgs);
     const thiz = this;
 
     const results = [];
     for (const argKey of argsKeys) {
-      const argText = this.findArgValue(discordMessage.content, definedArgs[argKey]);
+      const argText = this.findArgValue(message.content, definedArgs[argKey]);
       results.push(
         definedArgs[argKey].scanner
-          .scan(this.context, this.langManager, discordMessage, argText)
+          .scan(this.context, this.langManager, message, argText)
           .then(async scanResult => {
             let argValue = scanResult.value;
             thiz.context.log.d(
@@ -153,8 +153,8 @@ class DiscordCommand extends Command {
               scanResult = await definedArgs[argKey].scanner.scan(
                 thiz.context,
                 thiz.langManager,
-                discordMessage,
-                thiz.getDefaultDiscordArgValue(discordMessage, definedArgs[argKey])
+                message,
+                thiz.getDefaultDiscordArgValue(message, definedArgs[argKey])
               );
               argValue = scanResult.value;
               thiz.context.log.d(
@@ -186,14 +186,14 @@ class DiscordCommand extends Command {
    * @see CommandArgDef
    * @see Command.getDefinedArgs
    * @param  {Client}   client         the Discord client
-   * @param  {Message}  discordMessage the Discord message with the command
+   * @param  {BaseMessage}  message the Discord message with the command
    * @return {Promise}                 nothing
    */
-  async parseFromDiscordSequentially(client, discordMessage) {
+  async parseFromDiscordSequentially(client, message) {
     const definedArgs = this.constructor.getDefinedArgs();
     const argsKeys = Object.keys(definedArgs);
 
-    const trimmedContent = OhUtils.dry(discordMessage.content);
+    const trimmedContent = OhUtils.dry(message.content);
     let remainingArgText = '';
     if (trimmedContent.indexOf(' ') > 0) {
       remainingArgText = trimmedContent.slice(Math.max(0, trimmedContent.indexOf(' ') + 1));
@@ -202,13 +202,13 @@ class DiscordCommand extends Command {
     for (const argKey of argsKeys) {
       let argValue = null;
       if (definedArgs[argKey].skipInSequentialRead) {
-        const defaultValue = this.getDefaultDiscordArgValue(discordMessage, definedArgs[argKey]);
+        const defaultValue = this.getDefaultDiscordArgValue(message, definedArgs[argKey]);
         // Must scan arguments one by one, since it's a sequential scan, and results depend on previous scanning.
         /* eslint-disable no-await-in-loop */
         const scanResult = await definedArgs[argKey].scanner.scan(
           this.context,
           this.langManager,
-          discordMessage,
+          message,
           defaultValue
         );
         /* eslint-enable no-await-in-loop */
@@ -221,13 +221,13 @@ class DiscordCommand extends Command {
         );
       } else {
         if (remainingArgText === '') {
-          const defaultValue = this.getDefaultDiscordArgValue(discordMessage, definedArgs[argKey]);
+          const defaultValue = this.getDefaultDiscordArgValue(message, definedArgs[argKey]);
           // Must scan arguments one by one, since it's a sequential scan, and results depend on previous scanning.
           /* eslint-disable no-await-in-loop */
           const scanResult = await definedArgs[argKey].scanner.scan(
             this.context,
             this.langManager,
-            discordMessage,
+            message,
             defaultValue
           );
           /* eslint-enable no-await-in-loop */
@@ -244,7 +244,7 @@ class DiscordCommand extends Command {
           const scanResult = await definedArgs[argKey].scanner.scan(
             this.context,
             this.langManager,
-            discordMessage,
+            message,
             remainingArgText
           );
           /* eslint-enable no-await-in-loop */
@@ -276,20 +276,20 @@ class DiscordCommand extends Command {
    * (e.g. '!kill Bill knife').
    * After finishing the scanning, launches the arguments validation.
    * @param  {Client}   client         the Discord client
-   * @param  {Message}  discordMessage the Discord message with the command
+   * @param  {BaseMessage}  message the Discord message with the command
    * @return {Promise}                 nothing
    */
-  async parseFromDiscord(client, discordMessage) {
-    const index = OhUtils.findFirstNonQuotedIndex(discordMessage.content, this.constructor.ARG_PREFIX);
+  async parseFromDiscord(client, message) {
+    const index = OhUtils.findFirstNonQuotedIndex(message.content, this.constructor.ARG_PREFIX);
     if (index === -1) {
       this.context.log.d('Sequential arg scan');
-      await this.parseFromDiscordSequentially(client, discordMessage);
+      await this.parseFromDiscordSequentially(client, message);
     } else {
       this.context.log.d('Arg scan by name');
-      await this.parseFromDiscordByNames(client, discordMessage);
+      await this.parseFromDiscordByNames(client, message);
     }
 
-    await this.validateFromDiscord(client, discordMessage);
+    await this.validateFromDiscord(client, message);
   }
 }
 

--- a/src/commands_discord/discord-command.js
+++ b/src/commands_discord/discord-command.js
@@ -129,11 +129,10 @@ class DiscordCommand extends Command {
    * In any case, all defined arguments will have at least null value after executing this function.
    * @see DiscordCommand#findArgValue
    * @see Command.getDefinedArgs
-   * @param  {Client}   client         the Discord client
    * @param  {BaseMessage}  message the Discord message with the command
    * @return {Promise}                 nothing
    */
-  async parseFromDiscordByNames(client, message) {
+  async parseFromDiscordByNames(message) {
     const definedArgs = this.constructor.getDefinedArgs();
     const argsKeys = Object.keys(definedArgs);
     const thiz = this;
@@ -185,11 +184,10 @@ class DiscordCommand extends Command {
    * In any case, all defined arguments will have at least null value after executing this function.
    * @see CommandArgDef
    * @see Command.getDefinedArgs
-   * @param  {Client}   client         the Discord client
    * @param  {BaseMessage}  message the Discord message with the command
    * @return {Promise}                 nothing
    */
-  async parseFromDiscordSequentially(client, message) {
+  async parseFromDiscordSequentially(message) {
     const definedArgs = this.constructor.getDefinedArgs();
     const argsKeys = Object.keys(definedArgs);
 
@@ -279,17 +277,17 @@ class DiscordCommand extends Command {
    * @param  {BaseMessage}  message the Discord message with the command
    * @return {Promise}                 nothing
    */
-  async parseFromDiscord(client, message) {
+  async parseFromDiscord(message) {
     const index = OhUtils.findFirstNonQuotedIndex(message.content, this.constructor.ARG_PREFIX);
     if (index === -1) {
       this.context.log.d('Sequential arg scan');
-      await this.parseFromDiscordSequentially(client, message);
+      await this.parseFromDiscordSequentially(message);
     } else {
       this.context.log.d('Arg scan by name');
-      await this.parseFromDiscordByNames(client, message);
+      await this.parseFromDiscordByNames( message);
     }
 
-    await this.validateFromDiscord(client, message);
+    await this.validateFromDiscord(message);
   }
 }
 

--- a/src/commands_discord/moderation/add-role-command.js
+++ b/src/commands_discord/moderation/add-role-command.js
@@ -109,9 +109,9 @@ class AddRoleCommand extends DiscordCommand {
     let errorPermissionsCount = 0;
 
     const context = this.context;
-    const members = await this.context.discordClient.guilds.cache.get(this.orgId).members.fetch();
+    const members = await message.source.client.guilds.cache.get(this.orgId).members.fetch();
     const membersArray = Array.from(members.values());
-    const roles = await this.context.discordClient.guilds.cache.get(this.orgId).roles.fetch();
+    const roles = await message.source.client.guilds.cache.get(this.orgId).roles.fetch();
     const rolesArray = Array.from(roles.cache.values());
     const resultArray = [];
 

--- a/src/commands_discord/moderation/add-role-command.js
+++ b/src/commands_discord/moderation/add-role-command.js
@@ -97,10 +97,10 @@ class AddRoleCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let addedCount = 0;

--- a/src/commands_discord/moderation/clean-command.js
+++ b/src/commands_discord/moderation/clean-command.js
@@ -100,14 +100,14 @@ class CleanCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {BaseMessage}        message the command's message
+   * @param  {BaseMessage}    message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
   getDefaultDiscordArgValue(message, arg) {
     switch (arg) {
       case CleanCommandArgDefs.channelIds:
-        return message.channel.id;
+        return message.channelId;
       default:
         return null;
     }

--- a/src/commands_discord/moderation/clean-command.js
+++ b/src/commands_discord/moderation/clean-command.js
@@ -136,7 +136,7 @@ class CleanCommand extends DiscordCommand {
       let needRefetch = false;
       do {
         needRefetch = false;
-        const channel = this.context.discordClient.guilds.cache
+        const channel = message.source.client.guilds.cache
           .get(this.orgId)
           .channels.cache.get(this.channelIds.channels[i]);
         const messages = await channel.messages.fetch({ limit: MESSAGES_FETCH_LIMIT });

--- a/src/commands_discord/moderation/clean-command.js
+++ b/src/commands_discord/moderation/clean-command.js
@@ -100,7 +100,7 @@ class CleanCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {Message}        message the command's message
+   * @param  {BaseMessage}        message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -117,13 +117,13 @@ class CleanCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
-    const timestampLimit = discordMessage.createdTimestamp - this.time.totalMillisecondsShift;
+    const timestampLimit = message.originalMessage.createdTimestamp - this.time.totalMillisecondsShift;
 
     let deletedCount = 0;
     let checkedCount = 0;

--- a/src/commands_discord/moderation/remove-role-command.js
+++ b/src/commands_discord/moderation/remove-role-command.js
@@ -97,10 +97,10 @@ class RemoveRoleCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let removedCount = 0;

--- a/src/commands_discord/moderation/remove-role-command.js
+++ b/src/commands_discord/moderation/remove-role-command.js
@@ -108,9 +108,9 @@ class RemoveRoleCommand extends DiscordCommand {
     let errorCount = 0;
     let errorPermissionsCount = 0;
 
-    const members = await this.context.discordClient.guilds.cache.get(this.orgId).members.fetch();
+    const members = await message.source.client.guilds.cache.get(this.orgId).members.fetch();
     const membersArray = Array.from(members.values());
-    const roles = await this.context.discordClient.guilds.cache.get(this.orgId).roles.fetch();
+    const roles = await message.source.client.guilds.cache.get(this.orgId).roles.fetch();
     const rolesArray = Array.from(roles.cache.values());
     const resultArray = [];
 

--- a/src/commands_discord/other/help-command.js
+++ b/src/commands_discord/other/help-command.js
@@ -88,7 +88,7 @@ class HelpCommand extends DiscordCommand {
       this.source,
       this.orgId,
       ServerSettingsTable.SERVER_SETTINGS.commandPrefix.name,
-      DiscordCommand.DEFAULT_COMMAND_PREFIX
+      message.source.DEFAULT_COMMAND_PREFIX
     );
 
     if (this.command === null || this.langManager.getString(AllArgId) === this.command) {
@@ -157,12 +157,12 @@ class HelpCommand extends DiscordCommand {
    * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async getHelpCommandString(commandName) {
+  async getHelpCommandString(commandName, source) {
     const currentPrefix = await this.context.dbManager.getSetting(
       this.source,
       this.orgId,
       ServerSettingsTable.SERVER_SETTINGS.commandPrefix.name,
-      DiscordCommand.DEFAULT_COMMAND_PREFIX
+      source.DEFAULT_COMMAND_PREFIX
     );
 
     return (

--- a/src/commands_discord/other/help-command.js
+++ b/src/commands_discord/other/help-command.js
@@ -92,7 +92,7 @@ class HelpCommand extends DiscordCommand {
     );
 
     if (this.command === null || this.langManager.getString(AllArgId) === this.command) {
-      let commands = this.context.commandsParser.getDefinedDiscordCommands();
+      let commands = message.source.commandManager.definedCommands;
       if (
         this.langManager.getString(AllArgId) !== this.command &&
         !this.context.permManager.isAuthorAdmin(message)
@@ -116,7 +116,7 @@ class HelpCommand extends DiscordCommand {
           '\n';
       }
     } else {
-      const commands = this.context.commandsParser.getDefinedDiscordCommands();
+      const commands = message.source.commandManager.definedCommands;
       let selectedCommand = null;
       for (const command of commands) {
         if (this.langManager.getString(command.getCommandInterfaceName()) === this.command) {
@@ -150,13 +150,7 @@ class HelpCommand extends DiscordCommand {
     return result;
   }
 
-  /**
-   * Executes the command instance. The main function of a command, it's essence.
-   * All arguments scanning, validation and permissions check is considered done before entering this functions.
-   * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {BaseMessage}         message the Discord message as the source of the command
-   * @return {Promise<string>}                the result text to be replied as the response of the execution
-   */
+
   async getHelpCommandString(commandName, source) {
     const currentPrefix = await this.context.dbManager.getSetting(
       this.source,

--- a/src/commands_discord/other/help-command.js
+++ b/src/commands_discord/other/help-command.js
@@ -76,10 +76,10 @@ class HelpCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let result = '';
@@ -95,7 +95,7 @@ class HelpCommand extends DiscordCommand {
       let commands = this.context.commandsParser.getDefinedDiscordCommands();
       if (
         this.langManager.getString(AllArgId) !== this.command &&
-        !this.context.permManager.isAuthorAdmin(discordMessage)
+        !this.context.permManager.isAuthorAdmin(message)
       ) {
         commands = commands.filter((value, index, array) => {
           return !value.getRequiredDiscordPermissions().includes(PermissionsManager.DISCORD_PERMISSIONS.ADMINISTRATOR);
@@ -154,7 +154,7 @@ class HelpCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this functions.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
   async getHelpCommandString(commandName) {

--- a/src/commands_discord/other/ping-command.js
+++ b/src/commands_discord/other/ping-command.js
@@ -50,13 +50,13 @@ class PingCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
-    this.context.log.v('ping message timestamp: ', discordMessage.createdTimestamp);
+    this.context.log.v('ping message timestamp: ', message.originalMessage.createdTimestamp);
     return this.langManager.getString('command_ping_success');
   }
 }

--- a/src/commands_discord/permissions/add-role-manager-command.js
+++ b/src/commands_discord/permissions/add-role-manager-command.js
@@ -91,10 +91,10 @@ class AddRoleManagerCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     const currentRows = await this.context.dbManager.getDiscordRows(

--- a/src/commands_discord/permissions/deny-remind-command.js
+++ b/src/commands_discord/permissions/deny-remind-command.js
@@ -88,7 +88,7 @@ class DenyRemindCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {BaseMessage}        message the command's message
+   * @param  {BaseMessage}    message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */

--- a/src/commands_discord/permissions/deny-remind-command.js
+++ b/src/commands_discord/permissions/deny-remind-command.js
@@ -88,7 +88,7 @@ class DenyRemindCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {Message}        message the command's message
+   * @param  {BaseMessage}        message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -105,10 +105,10 @@ class DenyRemindCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let count = 0;

--- a/src/commands_discord/permissions/my-permissions-command.js
+++ b/src/commands_discord/permissions/my-permissions-command.js
@@ -92,7 +92,7 @@ class MyPermissionsCommand extends PermissionsCommand {
     }
 
     orArray.push({
-      $and: [{ subjectType: PermissionsManager.SUBJECT_TYPES.user.name }, { subjectId: message.originalMessage.member.id }]
+      $and: [{ subjectType: PermissionsManager.SUBJECT_TYPES.user.name }, { subjectId: message.userId }]
     });
 
     const andArray = [{ $or: orArray }];

--- a/src/commands_discord/permissions/my-permissions-command.js
+++ b/src/commands_discord/permissions/my-permissions-command.js
@@ -61,16 +61,16 @@ class MyPermissionsCommand extends PermissionsCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     // Keep "return await" to properly catch exceptions from the inside.
     /* eslint-disable no-return-await */
     return await this.getPermissionsDescription(
-      discordMessage,
+      message,
       'command_mypermissions_no_permissions',
       'command_mypermissions_permission'
     );
@@ -79,11 +79,11 @@ class MyPermissionsCommand extends PermissionsCommand {
 
   /**
    * Gets the filter object for permissions query.
-   * @param  {Message} discordMessage  the Discord message
+   * @param  {BaseMessage} message  the Discord message
    * @return {Object}                  the filter
    */
-  getFilter(discordMessage) {
-    const rolesArray = discordMessage.member.roles.cache.array();
+  getFilter(message) {
+    const rolesArray = message.originalMessage.member.roles.cache.array();
     const orArray = [];
     for (const role of rolesArray) {
       orArray.push({
@@ -92,7 +92,7 @@ class MyPermissionsCommand extends PermissionsCommand {
     }
 
     orArray.push({
-      $and: [{ subjectType: PermissionsManager.SUBJECT_TYPES.user.name }, { subjectId: discordMessage.member.id }]
+      $and: [{ subjectType: PermissionsManager.SUBJECT_TYPES.user.name }, { subjectId: message.originalMessage.member.id }]
     });
 
     const andArray = [{ $or: orArray }];

--- a/src/commands_discord/permissions/permissions-command.js
+++ b/src/commands_discord/permissions/permissions-command.js
@@ -82,11 +82,11 @@ class PermissionsCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     if (this.permType !== null) {
       let foundIndex = -1;
@@ -111,16 +111,16 @@ class PermissionsCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     // Keep "return await" to properly catch exceptions from the inside.
     /* eslint-disable no-return-await */
     return await this.getPermissionsDescription(
-      discordMessage,
+      message,
       'command_permissions_no_permissions',
       'command_permissions_permission'
     );
@@ -129,10 +129,10 @@ class PermissionsCommand extends DiscordCommand {
 
   /**
    * Gets the filter object for permissions query.
-   * @param  {Message} discordMessage  the Discord message
+   * @param  {BaseMessage} message  the Discord message
    * @return {Object}                  the filter
    */
-  getFilter(discordMessage) {
+  getFilter(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let typeFilter = {};
@@ -145,13 +145,13 @@ class PermissionsCommand extends DiscordCommand {
 
   /**
    * Gets a summarized list of peermissions description according to the filter.
-   * @param  {Message}         discordMessage the Discord message with the command
+   * @param  {BaseMessage}         message the Discord message with the command
    * @param  {string}          emptyTextId    the text id to be used in case of no matching permissions found
    * @param  {string}          resultTextId   the text id to be used in case of matching permissions are found
    * @return {Promise<string>}                the result string to be replier the the caller
    */
-  async getPermissionsDescription(discordMessage, emptyTextId, resultTextId) {
-    const filter = this.getFilter(discordMessage);
+  async getPermissionsDescription(message, emptyTextId, resultTextId) {
+    const filter = this.getFilter(message);
 
     const permissions = await this.context.dbManager.getDiscordRows(
       this.context.dbManager.permissionsTable,

--- a/src/commands_discord/permissions/permit-remind-command.js
+++ b/src/commands_discord/permissions/permit-remind-command.js
@@ -89,7 +89,7 @@ class PermitRemindCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {Message}        message the command's message
+   * @param  {BaseMessage}        message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -106,10 +106,10 @@ class PermitRemindCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     const currentRows = await this.context.dbManager.getDiscordRows(

--- a/src/commands_discord/permissions/permit-remind-command.js
+++ b/src/commands_discord/permissions/permit-remind-command.js
@@ -89,7 +89,7 @@ class PermitRemindCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {BaseMessage}        message the command's message
+   * @param  {BaseMessage}    message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */

--- a/src/commands_discord/permissions/remove-role-manager-command.js
+++ b/src/commands_discord/permissions/remove-role-manager-command.js
@@ -93,7 +93,7 @@ class RemoveRoleManagerCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {Message}        message the command's message
+   * @param  {BaseMessage}        message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -112,10 +112,10 @@ class RemoveRoleManagerCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let count = 0;

--- a/src/commands_discord/permissions/remove-role-manager-command.js
+++ b/src/commands_discord/permissions/remove-role-manager-command.js
@@ -93,7 +93,7 @@ class RemoveRoleManagerCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {BaseMessage}        message the command's message
+   * @param  {BaseMessage}    message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */

--- a/src/commands_discord/private_privacy/my-data-command.js
+++ b/src/commands_discord/private_privacy/my-data-command.js
@@ -52,17 +52,17 @@ class MyDataCommand extends DiscordPrivateCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     // Keep "return await" to properly catch exceptions from the inside.
     /* eslint-disable no-return-await */
     return await this.context.dbManager.getUserData(
       BotTable.DISCORD_SOURCE,
-      discordMessage.author.id,
+      message.userId,
       this.commandLangManager
     );
     /* eslint-enable no-return-await */

--- a/src/commands_discord/private_privacy/my-data-command.js
+++ b/src/commands_discord/private_privacy/my-data-command.js
@@ -6,8 +6,6 @@
  * @license MIT (see the root LICENSE file for details)
  */
 
-const BotTable = require('../../mongo_classes/bot-table');
-
 const DiscordPrivateCommand = require('../discord-private-command');
 
 /**

--- a/src/commands_discord/private_privacy/my-data-command.js
+++ b/src/commands_discord/private_privacy/my-data-command.js
@@ -61,7 +61,7 @@ class MyDataCommand extends DiscordPrivateCommand {
     // Keep "return await" to properly catch exceptions from the inside.
     /* eslint-disable no-return-await */
     return await this.context.dbManager.getUserData(
-      BotTable.DISCORD_SOURCE,
+      message.source.name,
       message.userId,
       this.commandLangManager
     );

--- a/src/commands_discord/settings/add-bad-words-command.js
+++ b/src/commands_discord/settings/add-bad-words-command.js
@@ -82,10 +82,10 @@ class AddBadWordsCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                 the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     const currentWordsString = await this.context.dbManager.getSetting(

--- a/src/commands_discord/settings/bad-words-command.js
+++ b/src/commands_discord/settings/bad-words-command.js
@@ -64,10 +64,10 @@ class BadWordsCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     const currentWordsString = await this.context.dbManager.getSetting(

--- a/src/commands_discord/settings/my-settings-command.js
+++ b/src/commands_discord/settings/my-settings-command.js
@@ -72,11 +72,11 @@ class MySettingsCommand extends SettingsCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     if (this.setting !== null) {
       const availableSettings = Object.values(UserSettingsTable.USER_SETTINGS);
@@ -97,16 +97,16 @@ class MySettingsCommand extends SettingsCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     // Keep "return await" to properly catch exceptions from the inside.
     /* eslint-disable no-return-await */
     return await this.getSettingsDescription(
-      discordMessage,
+      message,
       UserSettingsTable.USER_SETTINGS,
       'command_mysettings_empty_setting',
       this.context.dbManager.getUserSetting,

--- a/src/commands_discord/settings/remove-bad-words-command.js
+++ b/src/commands_discord/settings/remove-bad-words-command.js
@@ -82,10 +82,10 @@ class RemoveBadWordsCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     const currentWordsString = await this.context.dbManager.getSetting(

--- a/src/commands_discord/settings/set-censoring-command.js
+++ b/src/commands_discord/settings/set-censoring-command.js
@@ -85,10 +85,10 @@ class SetCensoringCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let value = null;

--- a/src/commands_discord/settings/set-locale-command.js
+++ b/src/commands_discord/settings/set-locale-command.js
@@ -84,11 +84,11 @@ class SetLocaleCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     const locales = this.langManager.getLocales();
     let found = false;
@@ -113,10 +113,10 @@ class SetLocaleCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     await this.context.dbManager.setSetting(

--- a/src/commands_discord/settings/set-my-locale-command.js
+++ b/src/commands_discord/settings/set-my-locale-command.js
@@ -73,11 +73,11 @@ class SetMyLocaleCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     if (this.locale === null) {
       return;
@@ -106,31 +106,31 @@ class SetMyLocaleCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     if (this.locale === null) {
       await this.context.dbManager.removeUserSetting(
         this.source,
         this.orgId,
-        discordMessage.member.id,
+        message.originalMessage.member.id,
         UserSettingsTable.USER_SETTINGS.localeName.name
       );
 
       this.context.log.i("SetMyLocaleCommand done: removed the user's locale preference");
       return this.langManager.getString(
         'command_setmylocale_success_no_locale',
-        DiscordUtils.makeUserMention(discordMessage.member.id)
+        DiscordUtils.makeUserMention(message.originalMessage.member.id)
       );
     }
 
     await this.context.dbManager.setUserSetting(
       this.source,
       this.orgId,
-      discordMessage.member.id,
+      message.originalMessage.member.id,
       UserSettingsTable.USER_SETTINGS.localeName.name,
       this.locale
     );
@@ -138,7 +138,7 @@ class SetMyLocaleCommand extends DiscordCommand {
     this.context.log.i("SetMyLocaleCommand done: new user's locale is " + this.locale);
     return this.langManager.getString(
       'command_setmylocale_success',
-      DiscordUtils.makeUserMention(discordMessage.member.id),
+      DiscordUtils.makeUserMention(message.originalMessage.member.id),
       this.locale
     );
   }

--- a/src/commands_discord/settings/set-my-locale-command.js
+++ b/src/commands_discord/settings/set-my-locale-command.js
@@ -116,21 +116,21 @@ class SetMyLocaleCommand extends DiscordCommand {
       await this.context.dbManager.removeUserSetting(
         this.source,
         this.orgId,
-        message.originalMessage.member.id,
+        message.userId,
         UserSettingsTable.USER_SETTINGS.localeName.name
       );
 
       this.context.log.i("SetMyLocaleCommand done: removed the user's locale preference");
       return this.langManager.getString(
         'command_setmylocale_success_no_locale',
-        DiscordUtils.makeUserMention(message.originalMessage.member.id)
+        DiscordUtils.makeUserMention(message.userId)
       );
     }
 
     await this.context.dbManager.setUserSetting(
       this.source,
       this.orgId,
-      message.originalMessage.member.id,
+      message.userId,
       UserSettingsTable.USER_SETTINGS.localeName.name,
       this.locale
     );
@@ -138,7 +138,7 @@ class SetMyLocaleCommand extends DiscordCommand {
     this.context.log.i("SetMyLocaleCommand done: new user's locale is " + this.locale);
     return this.langManager.getString(
       'command_setmylocale_success',
-      DiscordUtils.makeUserMention(message.originalMessage.member.id),
+      DiscordUtils.makeUserMention(message.userId),
       this.locale
     );
   }

--- a/src/commands_discord/settings/set-my-timezone-command.js
+++ b/src/commands_discord/settings/set-my-timezone-command.js
@@ -82,11 +82,11 @@ class SetMyTimezoneCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     if (this.timezone === null) {
       return;
@@ -113,31 +113,31 @@ class SetMyTimezoneCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     if (this.timezone === null) {
       await this.context.dbManager.removeUserSetting(
         this.source,
         this.orgId,
-        discordMessage.member.id,
+        message.originalMessage.member.id,
         UserSettingsTable.USER_SETTINGS.timezone.name
       );
 
       this.context.log.i("SetMyTimezoneCommand done: removed the user's timezone preference");
       return this.langManager.getString(
         'command_setmytimezone_success_no_timezone',
-        DiscordUtils.makeUserMention(discordMessage.member.id)
+        DiscordUtils.makeUserMention(message.originalMessage.member.id)
       );
     }
 
     await this.context.dbManager.setUserSetting(
       this.source,
       this.orgId,
-      discordMessage.member.id,
+      message.originalMessage.member.id,
       UserSettingsTable.USER_SETTINGS.timezone.name,
       this.timezone
     );

--- a/src/commands_discord/settings/set-my-timezone-command.js
+++ b/src/commands_discord/settings/set-my-timezone-command.js
@@ -123,21 +123,21 @@ class SetMyTimezoneCommand extends DiscordCommand {
       await this.context.dbManager.removeUserSetting(
         this.source,
         this.orgId,
-        message.originalMessage.member.id,
+        message.userId,
         UserSettingsTable.USER_SETTINGS.timezone.name
       );
 
       this.context.log.i("SetMyTimezoneCommand done: removed the user's timezone preference");
       return this.langManager.getString(
         'command_setmytimezone_success_no_timezone',
-        DiscordUtils.makeUserMention(message.originalMessage.member.id)
+        DiscordUtils.makeUserMention(message.userId)
       );
     }
 
     await this.context.dbManager.setUserSetting(
       this.source,
       this.orgId,
-      message.originalMessage.member.id,
+      message.userId,
       UserSettingsTable.USER_SETTINGS.timezone.name,
       this.timezone
     );

--- a/src/commands_discord/settings/set-prefix-command.js
+++ b/src/commands_discord/settings/set-prefix-command.js
@@ -80,10 +80,10 @@ class SetPrefixCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     await this.context.dbManager.setSetting(

--- a/src/commands_discord/settings/set-timezone-command.js
+++ b/src/commands_discord/settings/set-timezone-command.js
@@ -93,11 +93,11 @@ class SetTimezoneCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     const availableTimezones = momentTz.tz.names();
 
@@ -114,10 +114,10 @@ class SetTimezoneCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     await this.context.dbManager.setSetting(

--- a/src/commands_discord/settings/settings-command.js
+++ b/src/commands_discord/settings/settings-command.js
@@ -92,11 +92,11 @@ class SettingsCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     if (this.setting !== null) {
       const availableSettings = Object.values(ServerSettingsTable.SERVER_SETTINGS);
@@ -113,16 +113,16 @@ class SettingsCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     // Keep "return await" to properly catch exceptions from the inside.
     /* eslint-disable no-return-await */
     return await this.getSettingsDescription(
-      discordMessage,
+      message,
       ServerSettingsTable.SERVER_SETTINGS,
       'command_settings_empty_setting',
       this.context.dbManager.getSetting,
@@ -133,18 +133,18 @@ class SettingsCommand extends DiscordCommand {
 
   /**
    * Makes a related settings description (single setting if the setting arg is specified).
-   * @param  {Message}        discordMessage    the Discord message with the command
+   * @param  {BaseMessage}        message    the Discord message with the command
    * @param  {Array<Object>}  availableSettings the array of available settings
    * @param  {string}         emptyTextId       the text id of string to be used if no settings are found
    * @param  {Function}       dbFunc            the DB function to fetch the settings
    * @param  {Boolean}        includeUser       true if need to include member id into the DB function call
    * @return {Promise<string>}                  [description]
    */
-  async getSettingsDescription(discordMessage, availableSettings, emptyTextId, dbFunc, includeUser) {
+  async getSettingsDescription(message, availableSettings, emptyTextId, dbFunc, includeUser) {
     dbFunc = dbFunc.bind(this.context.dbManager);
     if (this.setting !== null) {
       const value = includeUser
-        ? await dbFunc(this.source, this.orgId, discordMessage.member.id, availableSettings[this.setting].name)
+        ? await dbFunc(this.source, this.orgId, message.originalMessage.member.id, availableSettings[this.setting].name)
         : await dbFunc(this.source, this.orgId, availableSettings[this.setting].name);
       if (value !== undefined) {
         return this.langManager.getString(availableSettings[this.setting].textId) + ' : ' + value;
@@ -163,7 +163,7 @@ class SettingsCommand extends DiscordCommand {
 
       getResults.push(
         (includeUser
-          ? dbFunc(this.source, this.orgId, discordMessage.member.id, availableSettings[settingKey].name)
+          ? dbFunc(this.source, this.orgId, message.originalMessage.member.id, availableSettings[settingKey].name)
           : dbFunc(this.source, this.orgId, availableSettings[settingKey].name)
         ).then(value => {
           if (value !== undefined) {

--- a/src/commands_discord/settings/settings-command.js
+++ b/src/commands_discord/settings/settings-command.js
@@ -133,7 +133,7 @@ class SettingsCommand extends DiscordCommand {
 
   /**
    * Makes a related settings description (single setting if the setting arg is specified).
-   * @param  {BaseMessage}        message    the Discord message with the command
+   * @param  {BaseMessage}    message    the Discord message with the command
    * @param  {Array<Object>}  availableSettings the array of available settings
    * @param  {string}         emptyTextId       the text id of string to be used if no settings are found
    * @param  {Function}       dbFunc            the DB function to fetch the settings
@@ -144,7 +144,7 @@ class SettingsCommand extends DiscordCommand {
     dbFunc = dbFunc.bind(this.context.dbManager);
     if (this.setting !== null) {
       const value = includeUser
-        ? await dbFunc(this.source, this.orgId, message.originalMessage.member.id, availableSettings[this.setting].name)
+        ? await dbFunc(this.source, this.orgId, message.userId, availableSettings[this.setting].name)
         : await dbFunc(this.source, this.orgId, availableSettings[this.setting].name);
       if (value !== undefined) {
         return this.langManager.getString(availableSettings[this.setting].textId) + ' : ' + value;
@@ -163,7 +163,7 @@ class SettingsCommand extends DiscordCommand {
 
       getResults.push(
         (includeUser
-          ? dbFunc(this.source, this.orgId, message.originalMessage.member.id, availableSettings[settingKey].name)
+          ? dbFunc(this.source, this.orgId, message.userId, availableSettings[settingKey].name)
           : dbFunc(this.source, this.orgId, availableSettings[settingKey].name)
         ).then(value => {
           if (value !== undefined) {

--- a/src/commands_discord/social/delete-reminder-command.js
+++ b/src/commands_discord/social/delete-reminder-command.js
@@ -95,11 +95,11 @@ class DeleteReminderCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     // Set channelIds for the PermissionsManager
     const channels = [];
@@ -125,10 +125,10 @@ class DeleteReminderCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     if (this.channelIds.length === 0) {

--- a/src/commands_discord/social/poll-command.js
+++ b/src/commands_discord/social/poll-command.js
@@ -95,11 +95,11 @@ class PollCommand extends DiscordCommand {
    * Throws BotPublicError if any of the validations was violated.
    * @see CommandArgDef
    * @throws {BotPublicError}
-   * @param  {Message}  discordMessage the command's message
+   * @param  {BaseMessage}  message the command's message
    * @return {Promise}                 nothing
    */
-  async validateFromDiscord(discordMessage) {
-    await super.validateFromDiscord(discordMessage);
+  async validateFromDiscord(message) {
+    await super.validateFromDiscord(message);
 
     if (this.answers !== null && this.answers.length > MaxAnswers) {
       throw new BotPublicError(
@@ -112,10 +112,10 @@ class PollCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     const pollEmbed = new Discord.MessageEmbed().setTitle(this.question);
@@ -129,7 +129,7 @@ class PollCommand extends DiscordCommand {
       pollEmbed.setDescription(description);
     }
 
-    const pollMessage = await discordMessage.channel.send(pollEmbed);
+    const pollMessage = await message.originalMessage.channel.send(pollEmbed);
 
     if (this.answers !== null && this.answers.length > 0) {
       for (let i = 0; i < this.answers.length; i++) {
@@ -143,7 +143,7 @@ class PollCommand extends DiscordCommand {
       await pollMessage.react('👎');
     }
 
-    await discordMessage.delete();
+    await message.originalMessage.delete();
     return '';
   }
 }

--- a/src/commands_discord/social/remind-command.js
+++ b/src/commands_discord/social/remind-command.js
@@ -107,14 +107,14 @@ class RemindCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {BaseMessage}        message the command's message
+   * @param  {BaseMessage}    message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
   getDefaultDiscordArgValue(message, arg) {
     switch (arg) {
       case RemindCommandArgDefs.channelIds:
-        return message.channel.id;
+        return message.channelId;
       default:
         return null;
     }

--- a/src/commands_discord/social/remind-command.js
+++ b/src/commands_discord/social/remind-command.js
@@ -107,7 +107,7 @@ class RemindCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {Message}        message the command's message
+   * @param  {BaseMessage}        message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -124,10 +124,10 @@ class RemindCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let result = '';

--- a/src/commands_discord/social/reminders-command.js
+++ b/src/commands_discord/social/reminders-command.js
@@ -94,7 +94,7 @@ class RemindersCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {BaseMessage}        message the command's message
+   * @param  {BaseMessage}    message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */

--- a/src/commands_discord/social/reminders-command.js
+++ b/src/commands_discord/social/reminders-command.js
@@ -94,7 +94,7 @@ class RemindersCommand extends DiscordCommand {
   /**
    * Gets the default value for a given argument definition.
    * Used when unable to scan the argument from the command's text.
-   * @param  {Message}        message the command's message
+   * @param  {BaseMessage}        message the command's message
    * @param  {CommandArgDef}  arg     the argument definition
    * @return {Object}                 the default value
    */
@@ -111,10 +111,10 @@ class RemindersCommand extends DiscordCommand {
    * Executes the command instance. The main function of a command, it's essence.
    * All arguments scanning, validation and permissions check is considered done before entering this function.
    * So if any exception happens inside the function, it's considered a Bot's internal problem.
-   * @param  {Message}         discordMessage the Discord message as the source of the command
+   * @param  {BaseMessage}         message the Discord message as the source of the command
    * @return {Promise<string>}                the result text to be replied as the response of the execution
    */
-  async executeForDiscord(discordMessage) {
+  async executeForDiscord(message) {
     // Inherited function with various possible implementations, some args may be unused.
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
     let channelsFilter = {};

--- a/src/components/base-message.js
+++ b/src/components/base-message.js
@@ -1,0 +1,23 @@
+'use strict';
+
+class BaseMessage {
+
+  constructor(teamId, channelId, userId, content, originalMessage) {
+    this.teamId = teamId;
+    this.channelId = channelId;
+    this.userId = userId;
+    this.content = content;
+    this.originalMessage = originalMessage;
+
+  }
+
+  static createFromSlack(slackMessage) {
+    return new BaseMessage(slackMessage.team_id, slackMessage.channel, slackMessage.user, slackMessage.text, slackMessage);
+  }
+
+  static createFromDiscord(discordMessage) {
+    return new BaseMessage(discordMessage.guild.id, discordMessage.channel.id, discordMessage.author.id, discordMessage.content, discordMessage);
+  }
+}
+
+module.exports = BaseMessage;

--- a/src/components/base-message.js
+++ b/src/components/base-message.js
@@ -9,7 +9,6 @@ class BaseMessage {
     this.content = content;
     this.originalMessage = originalMessage;
     this.source = source;
-
   }
 
   static createFromSlack(slackMessage, slackSource) {

--- a/src/components/base-message.js
+++ b/src/components/base-message.js
@@ -1,9 +1,19 @@
 'use strict';
 
+/**
+ * Wrapper for a source specific message
+ */
 class BaseMessage {
-
-  constructor(teamId, channelId, userId, content, originalMessage, source) {
-    this.teamId = teamId;
+  /**
+   * @param {String} orgId
+   * @param {String} channelId
+   * @param {String} userId
+   * @param {String} content
+   * @param {?} originalMessage
+   * @param {BaseSource} source
+   */
+  constructor(orgId, channelId, userId, content, originalMessage, source) {
+    this.orgId = orgId;
     this.channelId = channelId;
     this.userId = userId;
     this.content = content;
@@ -11,16 +21,47 @@ class BaseMessage {
     this.source = source;
   }
 
+  /**
+   * Create BaseMessage from a Slack message
+   * @param slackMessage
+   * @param slackSource
+   * @returns {BaseMessage}
+   */
   static createFromSlack(slackMessage, slackSource) {
-    return new BaseMessage(slackMessage.team_id, slackMessage.channel, slackMessage.user, slackMessage.text,
-      slackMessage, slackSource);
+    return new BaseMessage(
+      slackMessage.team_id,
+      slackMessage.channel,
+      slackMessage.user,
+      slackMessage.text,
+      slackMessage,
+      slackSource
+    );
   }
 
+  /**
+   * Create BaseMessage from a Discord message
+   * @param discordMessage
+   * @param discordSource
+   * @returns {BaseMessage}
+   */
   static createFromDiscord(discordMessage, discordSource) {
-    return new BaseMessage(discordMessage.guild.id, discordMessage.channel.id, discordMessage.author.id,
-      discordMessage.content, discordMessage, discordSource);
+    console.log(discordMessage.member.id);
+    console.log(discordMessage.author.id);
+    return new BaseMessage(
+      discordMessage.guild ? discordMessage.guild.id : null,
+      discordMessage.channel ? discordMessage.channel.id : null,
+      discordMessage.author ? discordMessage.author.id : null,
+      discordMessage.content,
+      discordMessage,
+      discordSource
+    );
   }
 
+  /**
+   * Simple reply to a message with a text
+   * @param text
+   * @returns {Promise<void>}
+   */
   async reply(text) {
     this.source.replyToMessage(this, text);
   }

--- a/src/components/base-message.js
+++ b/src/components/base-message.js
@@ -2,21 +2,28 @@
 
 class BaseMessage {
 
-  constructor(teamId, channelId, userId, content, originalMessage) {
+  constructor(teamId, channelId, userId, content, originalMessage, source) {
     this.teamId = teamId;
     this.channelId = channelId;
     this.userId = userId;
     this.content = content;
     this.originalMessage = originalMessage;
+    this.source = source;
 
   }
 
-  static createFromSlack(slackMessage) {
-    return new BaseMessage(slackMessage.team_id, slackMessage.channel, slackMessage.user, slackMessage.text, slackMessage);
+  static createFromSlack(slackMessage, slackSource) {
+    return new BaseMessage(slackMessage.team_id, slackMessage.channel, slackMessage.user, slackMessage.text,
+      slackMessage, slackSource);
   }
 
-  static createFromDiscord(discordMessage) {
-    return new BaseMessage(discordMessage.guild.id, discordMessage.channel.id, discordMessage.author.id, discordMessage.content, discordMessage);
+  static createFromDiscord(discordMessage, discordSource) {
+    return new BaseMessage(discordMessage.guild.id, discordMessage.channel.id, discordMessage.author.id,
+      discordMessage.content, discordMessage, discordSource);
+  }
+
+  async reply(text) {
+    this.source.replyToMessage(this, text);
   }
 }
 

--- a/src/components/base-source.js
+++ b/src/components/base-source.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const DEFAULT_COMMAND_PREFIX = '!';
+
 class BaseSource {
 
   constructor(client) {
@@ -8,6 +10,14 @@ class BaseSource {
 
   async replyToMessage(message, replyText) {
     throw new Error('BaseSource is an abstract class');
+  }
+
+  get name() {
+    throw new Error('BaseSource is an abstract class');
+  }
+
+  get DEFAULT_COMMAND_PREFIX() {
+    return DEFAULT_COMMAND_PREFIX;
   }
 }
 

--- a/src/components/base-source.js
+++ b/src/components/base-source.js
@@ -2,20 +2,36 @@
 
 const DEFAULT_COMMAND_PREFIX = '!';
 
+/**
+ * Base class for a message sources
+ */
 class BaseSource {
-
   constructor(client) {
     this.client = client;
   }
 
+  /**
+   * Reply to the message using the source
+   * @param message
+   * @param replyText
+   * @returns {Promise<void>}
+   */
   async replyToMessage(message, replyText) {
-    throw new Error('BaseSource is an abstract class');
+    throw new Error(`${this.constructor.name} is an abstract class`);
   }
 
+  /**
+   * String name of the source
+   */
   get name() {
-    throw new Error('BaseSource is an abstract class');
+    throw new Error(`${this.constructor.name} is an abstract class`);
   }
 
+  /**
+   * Default command prefix
+   * @returns {string}
+   * @constructor
+   */
   get DEFAULT_COMMAND_PREFIX() {
     return DEFAULT_COMMAND_PREFIX;
   }

--- a/src/components/base-source.js
+++ b/src/components/base-source.js
@@ -1,0 +1,14 @@
+'use strict';
+
+class BaseSource {
+
+  constructor(client) {
+    this.client = client;
+  }
+
+  async replyToMessage(message, replyText) {
+    throw new Error('BaseSource is an abstract class');
+  }
+}
+
+module.exports = BaseSource;

--- a/src/components/command-manager.js
+++ b/src/components/command-manager.js
@@ -1,0 +1,21 @@
+'use strict';
+
+class CommandManager {
+  /**
+   * Gets the array of defined Discord command classes.
+   * @return {Array<constructor>} the defined commands
+   */
+  get definedCommands() {
+    throw new Error('CommandManager is an abstract class');
+  }
+
+  /**
+   * The defined private Discord command classes.
+   * @type {Array<constructor>}
+   */
+  get definedPrivateCommands() {
+    throw new Error('CommandManager is an abstract class');
+  }
+}
+
+module.exports = CommandManager;

--- a/src/components/command-manager.js
+++ b/src/components/command-manager.js
@@ -6,7 +6,7 @@ class CommandManager {
    * @return {Array<constructor>} the defined commands
    */
   get definedCommands() {
-    throw new Error('CommandManager is an abstract class');
+    throw new Error(`${this.constructor.name} is an abstract class`);
   }
 
   /**
@@ -14,7 +14,7 @@ class CommandManager {
    * @type {Array<constructor>}
    */
   get definedPrivateCommands() {
-    throw new Error('CommandManager is an abstract class');
+    throw new Error(`${this.constructor.name} is an abstract class`);
   }
 }
 

--- a/src/components/discord-command-manager.js
+++ b/src/components/discord-command-manager.js
@@ -7,6 +7,7 @@ const AddRoleManagerCommand = require('../commands_discord/permissions/add-role-
 const BadWordsCommand = require('../commands_discord/settings/bad-words-command');
 const CleanCommand = require('../commands_discord/moderation/clean-command');
 const DeleteReminderCommand = require('../commands_discord/social/delete-reminder-command');
+const DeletePermissionCommand = require('../commands_discord/permissions/delete-permission-command');
 const DenyRemindCommand = require('../commands_discord/permissions/deny-remind-command');
 const HelpCommand = require('../commands_discord/other/help-command');
 const MyPermissionsCommand = require('../commands_discord/permissions/my-permissions-command');
@@ -30,8 +31,10 @@ const SettingsCommand = require('../commands_discord/settings/settings-command')
 
 const MyDataCommand = require('../commands_discord/private_privacy/my-data-command');
 
+/**
+ * Class represents command available for the Discord
+ */
 class DiscordCommandManager extends CommandManager {
-
   /**
    * Gets the array of defined Discord command classes.
    * @return {Array<constructor>} the defined commands
@@ -44,6 +47,7 @@ class DiscordCommandManager extends CommandManager {
       BadWordsCommand,
       CleanCommand,
       DeleteReminderCommand,
+      DeletePermissionCommand,
       DenyRemindCommand,
       HelpCommand,
       MyPermissionsCommand,

--- a/src/components/discord-command-manager.js
+++ b/src/components/discord-command-manager.js
@@ -1,0 +1,79 @@
+'use strict';
+const CommandManager = require('./command-manager');
+
+const AddBadWordsCommand = require('../commands_discord/settings/add-bad-words-command');
+const AddRoleCommand = require('../commands_discord/moderation/add-role-command');
+const AddRoleManagerCommand = require('../commands_discord/permissions/add-role-manager-command');
+const BadWordsCommand = require('../commands_discord/settings/bad-words-command');
+const CleanCommand = require('../commands_discord/moderation/clean-command');
+const DeleteReminderCommand = require('../commands_discord/social/delete-reminder-command');
+const DenyRemindCommand = require('../commands_discord/permissions/deny-remind-command');
+const HelpCommand = require('../commands_discord/other/help-command');
+const MyPermissionsCommand = require('../commands_discord/permissions/my-permissions-command');
+const MySettingsCommand = require('../commands_discord/settings/my-settings-command');
+const PermissionsCommand = require('../commands_discord/permissions/permissions-command');
+const PermitRemindCommand = require('../commands_discord/permissions/permit-remind-command');
+const PingCommand = require('../commands_discord/other/ping-command');
+const PollCommand = require('../commands_discord/social/poll-command');
+const RemindCommand = require('../commands_discord/social/remind-command');
+const RemindersCommand = require('../commands_discord/social/reminders-command');
+const RemoveBadWordsCommand = require('../commands_discord/settings/remove-bad-words-command');
+const RemoveRoleCommand = require('../commands_discord/moderation/remove-role-command');
+const RemoveRoleManagerCommand = require('../commands_discord/permissions/remove-role-manager-command');
+const SetCensoringCommand = require('../commands_discord/settings/set-censoring-command');
+const SetLocaleCommand = require('../commands_discord/settings/set-locale-command');
+const SetMyLocaleCommand = require('../commands_discord/settings/set-my-locale-command');
+const SetMyTimezoneCommand = require('../commands_discord/settings/set-my-timezone-command');
+const SetPrefixCommand = require('../commands_discord/settings/set-prefix-command');
+const SetTimezoneCommand = require('../commands_discord/settings/set-timezone-command');
+const SettingsCommand = require('../commands_discord/settings/settings-command');
+
+const MyDataCommand = require('../commands_discord/private_privacy/my-data-command');
+
+class DiscordCommandManager extends CommandManager {
+
+  /**
+   * Gets the array of defined Discord command classes.
+   * @return {Array<constructor>} the defined commands
+   */
+  get definedCommands() {
+    return Object.freeze([
+      AddBadWordsCommand,
+      AddRoleCommand,
+      AddRoleManagerCommand,
+      BadWordsCommand,
+      CleanCommand,
+      DeleteReminderCommand,
+      DenyRemindCommand,
+      HelpCommand,
+      MyPermissionsCommand,
+      MySettingsCommand,
+      PermissionsCommand,
+      PermitRemindCommand,
+      PingCommand,
+      PollCommand,
+      RemindersCommand,
+      RemindCommand,
+      RemoveBadWordsCommand,
+      RemoveRoleCommand,
+      RemoveRoleManagerCommand,
+      SetCensoringCommand,
+      SetLocaleCommand,
+      SetMyLocaleCommand,
+      SetMyTimezoneCommand,
+      SetPrefixCommand,
+      SetTimezoneCommand,
+      SettingsCommand
+    ]);
+  }
+
+  /**
+   * The defined private Discord command classes.
+   * @type {Array<constructor>}
+   */
+  get definedPrivateCommands() {
+    return Object.freeze([MyDataCommand]);
+  }
+}
+
+module.exports = DiscordCommandManager;

--- a/src/components/discord-source.js
+++ b/src/components/discord-source.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const DiscordUtils = require('../utils/discord-utils');
+const BaseSource = require('./base-source');
+
+class DiscordSource extends BaseSource {
+  async replyToMessage(message, replyText) {
+    DiscordUtils.sendToTextChannel(message.originalMessage.channel, replyText);
+  }
+}
+
+module.exports = DiscordSource;

--- a/src/components/discord-source.js
+++ b/src/components/discord-source.js
@@ -5,16 +5,28 @@ const BaseSource = require('./base-source');
 const BotTable = require('../mongo_classes/bot-table');
 const DiscordCommandManager = require('../components/discord-command-manager');
 
+/**
+ * Discord source
+ */
 class DiscordSource extends BaseSource {
   constructor(client) {
     super(client);
     this.commandManager = new DiscordCommandManager();
   }
 
+  /**
+   * Reply to the message using the source
+   * @param message
+   * @param replyText
+   * @returns {Promise<void>}
+   */
   async replyToMessage(message, replyText) {
     DiscordUtils.sendToTextChannel(message.originalMessage.channel, replyText);
   }
 
+  /**
+   * String name of the source
+   */
   get name() {
     return BotTable.DISCORD_SOURCE;
   }

--- a/src/components/discord-source.js
+++ b/src/components/discord-source.js
@@ -3,8 +3,14 @@
 const DiscordUtils = require('../utils/discord-utils');
 const BaseSource = require('./base-source');
 const BotTable = require('../mongo_classes/bot-table');
+const DiscordCommandManager = require('../components/discord-command-manager');
 
 class DiscordSource extends BaseSource {
+  constructor(client) {
+    super(client);
+    this.commandManager = new DiscordCommandManager();
+  }
+
   async replyToMessage(message, replyText) {
     DiscordUtils.sendToTextChannel(message.originalMessage.channel, replyText);
   }

--- a/src/components/discord-source.js
+++ b/src/components/discord-source.js
@@ -2,10 +2,15 @@
 
 const DiscordUtils = require('../utils/discord-utils');
 const BaseSource = require('./base-source');
+const BotTable = require('../mongo_classes/bot-table');
 
 class DiscordSource extends BaseSource {
   async replyToMessage(message, replyText) {
     DiscordUtils.sendToTextChannel(message.originalMessage.channel, replyText);
+  }
+
+  get name() {
+    return BotTable.DISCORD_SOURCE;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const OhUtils = require('./utils/bot-utils');
 const BaseMessage = require('./components/base-message');
 const PrefsManager = require('./managers/prefs-manager');
 const Context = require('./managers/context');
-
+const DiscordSource = require('./components/discord-source');
 const prefsPath = path.join(__dirname, '..', 'preferences.txt');
 const localizationPath = path.join(__dirname, '..', 'localization');
 
@@ -23,9 +23,11 @@ const client = new Discord.Client();
 
 const prefsManager = new PrefsManager(prefsPath);
 
+
 prefsManager.readPrefs();
 
 const c = new Context(prefsManager, localizationPath, client);
+const discordSource = new DiscordSource(client);
 
 c.log.i('Context created.');
 
@@ -95,7 +97,7 @@ MongoClient.connect(dbConnectionString, async (err, db) => {
 
 
     try {
-      const message = BaseMessage.createFromDiscord(discordMessage);
+      const message = BaseMessage.createFromDiscord(discordMessage, discordSource);
       await c.dbManager.updateGuilds(client.guilds.cache);
       await c.scheduler.syncTasks();
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,10 +75,6 @@ MongoClient.connect(dbConnectionString, async (err, db) => {
       }
 
       await Promise.all(updateResults);
-
-      c.commandsParser.setDiscordClient(client);
-      c.messageModerator.setDiscordClient(client);
-
       await c.dbManager.updateGuilds(client.guilds.cache);
 
       c.discordClientReady = true;

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ MongoClient.connect(dbConnectionString, async (err, db) => {
 
         let processed = false;
         if (message.userId !== client.user.id) {
-          processed = await c.commandsParser.parseDiscordCommand(message);
+          processed = await c.commandsParser.processMessage(message);
           if (!processed) {
             c.messageModerator.premoderateDiscordMessage(message);
           }

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ const client = new Discord.Client();
 
 const prefsManager = new PrefsManager(prefsPath);
 
-
 prefsManager.readPrefs();
 
 const c = new Context(prefsManager, localizationPath, client);
@@ -91,13 +90,11 @@ MongoClient.connect(dbConnectionString, async (err, db) => {
       return;
     }
 
-
     try {
       const message = BaseMessage.createFromDiscord(discordMessage, discordSource);
       await c.dbManager.updateGuilds(client.guilds.cache);
       await c.scheduler.syncTasks();
 
-      // TODO: Is it discord only feature?
       if (message.originalMessage.guild !== undefined && message.originalMessage.guild !== null) {
         await c.dbManager.updateGuild(message.originalMessage.guild);
 

--- a/src/managers/commands-parser.js
+++ b/src/managers/commands-parser.js
@@ -127,7 +127,7 @@ class CommandsParser {
       UserSettingsTable.USER_SETTINGS.localeName.name
     );
 
-    return  new LangManager(
+    return new LangManager(
       this.context.localizationPath,
       currentUserLocale === undefined ? currentLocale : currentUserLocale
     );
@@ -191,7 +191,7 @@ class CommandsParser {
     }
 
     try {
-      await this.context.permManager.checkDiscordCommandPermissions(message.source.client, message, command);
+      await this.context.permManager.checkDiscordCommandPermissions(message, command);
     } catch (error) {
       this.context.log.w(
         'executeCommand: Not permitted to execute: "' +

--- a/src/managers/commands-parser.js
+++ b/src/managers/commands-parser.js
@@ -9,7 +9,6 @@
 const LangManager = require('./lang-manager');
 
 const BotPublicError = require('../utils/bot-public-error');
-const DiscordUtils = require('../utils/discord-utils');
 
 const BotTable = require('../mongo_classes/bot-table');
 const ServerSettingsTable = require('../mongo_classes/server-settings-table');
@@ -284,13 +283,10 @@ class CommandsParser {
         '; stack: ' +
         error.stack
       );
-      DiscordUtils.sendToTextChannel(
-        message.originalMessage.channel,
-        commandLangManager.getString(
-          'permission_command_error',
-          error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error')
-        )
-      );
+      message.reply(commandLangManager.getString(
+        'permission_command_error',
+        error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error')
+      ));
       return;
     }
 
@@ -306,18 +302,15 @@ class CommandsParser {
         '; stack: ' +
         error.stack
       );
-      DiscordUtils.sendToTextChannel(
-        message.originalMessage.channel,
-        commandLangManager.getString(
-          'execute_command_error',
-          error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error')
-        )
-      );
+      message.reply(commandLangManager.getString(
+        'execute_command_error',
+        error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error')
+      ));
       return;
     }
 
     if (result !== undefined && result !== null && result !== '') {
-      DiscordUtils.sendToTextChannel(message.originalMessage.channel, result);
+      message.reply(result);
     }
   }
 
@@ -350,18 +343,15 @@ class CommandsParser {
         '; stack: ' +
         error.stack
       );
-      DiscordUtils.sendToTextChannel(
-        message.originalMessage.channel,
-        commandLangManager.getString(
-          'execute_command_error',
-          error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error')
-        )
-      );
+      message.reply(commandLangManager.getString(
+        'execute_command_error',
+        error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error')
+      ));
       return;
     }
 
     if (result !== undefined && result !== null && result !== '') {
-      DiscordUtils.sendToTextChannel(message.originalMessage.channel, result);
+      message.reply(result);
     }
   }
 
@@ -393,19 +383,16 @@ class CommandsParser {
         '; stack: ' +
         error.stack
       );
-      DiscordUtils.sendToTextChannel(
-        message.originalMessage.channel,
-        commandLangManager.getString(
-          'validate_command_error',
-          error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error'),
-          await new HelpCommand(
-            this.context,
-            BotTable.DISCORD_SOURCE,
-            commandLangManager,
-            message.teamId
-          ).getHelpCommandString(commandClass.getCommandInterfaceName())
-        )
-      );
+      message.reply(commandLangManager.getString(
+        'validate_command_error',
+        error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error'),
+        await new HelpCommand(
+          this.context,
+          BotTable.DISCORD_SOURCE,
+          commandLangManager,
+          message.teamId
+        ).getHelpCommandString(commandClass.getCommandInterfaceName())
+      ));
       return null;
     }
 
@@ -435,14 +422,11 @@ class CommandsParser {
         '; stack: ' +
         error.stack
       );
-      DiscordUtils.sendToTextChannel(
-        message.originalMessage.channel,
-        commandLangManager.getString(
-          'validate_command_error',
-          error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error'),
-          '' // @todo Create a private HelpCommand class and use it here to provide help on the private commands.
-        )
-      );
+      message.reply(commandLangManager.getString(
+        'validate_command_error',
+        error instanceof BotPublicError ? error.message : commandLangManager.getString('internal_server_error'),
+        '' // @todo Create a private HelpCommand class and use it here to provide help on the private commands.
+      ));
       return null;
     }
 

--- a/src/managers/commands-parser.js
+++ b/src/managers/commands-parser.js
@@ -97,14 +97,6 @@ class CommandsParser {
   }
 
   /**
-   * Sets the Discord client for the instance.
-   * @param {Client} client the Discord client
-   */
-  setDiscordClient(client) {
-    this.discordClient = client;
-  }
-
-  /**
    * Gets the array of defined Discord command classes.
    * @return {Array<constructor>} the defined commands
    */
@@ -276,7 +268,7 @@ class CommandsParser {
     }
 
     try {
-      await this.context.permManager.checkDiscordCommandPermissions(this.discordClient, message, command);
+      await this.context.permManager.checkDiscordCommandPermissions(message.source.client, message, command);
     } catch (error) {
       this.context.log.w(
         'executeCommand: Not permitted to execute: "' +
@@ -376,7 +368,7 @@ class CommandsParser {
     );
 
     try {
-      await command.parseFromDiscord(this.discordClient, message);
+      await command.parseFromDiscord(message);
     } catch (error) {
       this.context.log.w(
         'tryParseDiscordCommand: failed to parse command: "' +
@@ -415,7 +407,7 @@ class CommandsParser {
     const command = commandClass.createForUser(this.context, message.source.name, commandLangManager);
 
     try {
-      await command.parseFromDiscord(this.discordClient, message);
+      await command.parseFromDiscord(message);
     } catch (error) {
       this.context.log.w(
         'tryParsePrivateDiscordCommand: failed to parse command: "' +

--- a/src/managers/commands-parser.js
+++ b/src/managers/commands-parser.js
@@ -13,75 +13,7 @@ const BotPublicError = require('../utils/bot-public-error');
 const ServerSettingsTable = require('../mongo_classes/server-settings-table');
 const UserSettingsTable = require('../mongo_classes/user-settings-table');
 
-const AddBadWordsCommand = require('../commands_discord/settings/add-bad-words-command');
-const AddRoleCommand = require('../commands_discord/moderation/add-role-command');
-const AddRoleManagerCommand = require('../commands_discord/permissions/add-role-manager-command');
-const BadWordsCommand = require('../commands_discord/settings/bad-words-command');
-const CleanCommand = require('../commands_discord/moderation/clean-command');
-const DeletePermissionCommand = require('../commands_discord/permissions/delete-permission-command');
-const DeleteReminderCommand = require('../commands_discord/social/delete-reminder-command');
-const DenyRemindCommand = require('../commands_discord/permissions/deny-remind-command');
 const HelpCommand = require('../commands_discord/other/help-command');
-const MyPermissionsCommand = require('../commands_discord/permissions/my-permissions-command');
-const MySettingsCommand = require('../commands_discord/settings/my-settings-command');
-const PermissionsCommand = require('../commands_discord/permissions/permissions-command');
-const PermitRemindCommand = require('../commands_discord/permissions/permit-remind-command');
-const PingCommand = require('../commands_discord/other/ping-command');
-const PollCommand = require('../commands_discord/social/poll-command');
-const RemindCommand = require('../commands_discord/social/remind-command');
-const RemindersCommand = require('../commands_discord/social/reminders-command');
-const RemoveBadWordsCommand = require('../commands_discord/settings/remove-bad-words-command');
-const RemoveRoleCommand = require('../commands_discord/moderation/remove-role-command');
-const RemoveRoleManagerCommand = require('../commands_discord/permissions/remove-role-manager-command');
-const SetCensoringCommand = require('../commands_discord/settings/set-censoring-command');
-const SetLocaleCommand = require('../commands_discord/settings/set-locale-command');
-const SetMyLocaleCommand = require('../commands_discord/settings/set-my-locale-command');
-const SetMyTimezoneCommand = require('../commands_discord/settings/set-my-timezone-command');
-const SetPrefixCommand = require('../commands_discord/settings/set-prefix-command');
-const SetTimezoneCommand = require('../commands_discord/settings/set-timezone-command');
-const SettingsCommand = require('../commands_discord/settings/settings-command');
-
-const MyDataCommand = require('../commands_discord/private_privacy/my-data-command');
-
-/**
- * The defined Discord command classes.
- * @type {Array<constructor>}
- */
-const DiscordCommands = Object.freeze([
-  AddBadWordsCommand,
-  AddRoleCommand,
-  AddRoleManagerCommand,
-  BadWordsCommand,
-  CleanCommand,
-  DeletePermissionCommand,
-  DeleteReminderCommand,
-  DenyRemindCommand,
-  HelpCommand,
-  MyPermissionsCommand,
-  MySettingsCommand,
-  PermissionsCommand,
-  PermitRemindCommand,
-  PingCommand,
-  PollCommand,
-  RemindersCommand,
-  RemindCommand,
-  RemoveBadWordsCommand,
-  RemoveRoleCommand,
-  RemoveRoleManagerCommand,
-  SetCensoringCommand,
-  SetLocaleCommand,
-  SetMyLocaleCommand,
-  SetMyTimezoneCommand,
-  SetPrefixCommand,
-  SetTimezoneCommand,
-  SettingsCommand
-]);
-
-/**
- * The defined private Discord command classes.
- * @type {Array<constructor>}
- */
-const DiscordPrivateCommands = Object.freeze([MyDataCommand]);
 
 /**
  * Parses and launches execution of the Bot's commands.
@@ -94,14 +26,6 @@ class CommandsParser {
    */
   constructor(context) {
     this.context = context;
-  }
-
-  /**
-   * Gets the array of defined Discord command classes.
-   * @return {Array<constructor>} the defined commands
-   */
-  getDefinedDiscordCommands() {
-    return DiscordCommands;
   }
 
   /**
@@ -179,7 +103,7 @@ class CommandsParser {
     );
     this.context.log.i('parseDiscordCommand: command: ' + message.content + '; commandName: ' + commandName);
 
-    for (const command of DiscordCommands) {
+    for (const command of message.source.commandManager.definedCommands) {
       if (commandName === commandLangManager.getString(command.getCommandInterfaceName())) {
         this.context.log.i('Found command: ' + message.content);
         return command;
@@ -203,11 +127,10 @@ class CommandsParser {
       UserSettingsTable.USER_SETTINGS.localeName.name
     );
 
-    const commandLangManager = new LangManager(
+    return  new LangManager(
       this.context.localizationPath,
       currentUserLocale === undefined ? currentLocale : currentUserLocale
     );
-    return commandLangManager;
   }
 
   /**
@@ -235,7 +158,7 @@ class CommandsParser {
     );
 
     let commandFound = false;
-    for (const command of DiscordPrivateCommands) {
+    for (const command of message.source.commandManager.definedPrivateCommands) {
       if (commandName === commandLangManager.getString(command.getCommandInterfaceName())) {
         this.context.log.i('Found private command: ' + message.content);
         commandFound = true;

--- a/src/managers/message-moderator.js
+++ b/src/managers/message-moderator.js
@@ -34,7 +34,7 @@ class MessageModerator {
   async premoderateDiscordMessage(message) {
     const censoringEnabled = await this.context.dbManager.getSetting(
       message.source.name,
-      message.teamId,
+      message.orgId,
       ServerSettingsTable.SERVER_SETTINGS.censoring.name,
       OhUtils.OFF
     );
@@ -42,7 +42,7 @@ class MessageModerator {
     if (censoringEnabled === OhUtils.ON) {
       const badWordsString = await this.context.dbManager.getSetting(
         message.source.name,
-        message.teamId,
+        message.orgId,
         ServerSettingsTable.SERVER_SETTINGS.badwords.name,
         ''
       );
@@ -58,11 +58,13 @@ class MessageModerator {
         }
 
         if (content !== message.content) {
-          await message.reply(this.context.langManager.getString(
-            'moderator_censored_message',
-            DiscordUtils.makeUserMention(message.originalMessage.member.id),
-            content
-          ));
+          await message.reply(
+            this.context.langManager.getString(
+              'moderator_censored_message',
+              DiscordUtils.makeUserMention(message.userId),
+              content
+            )
+          );
           await message.originalMessage.delete();
         }
       }

--- a/src/managers/message-moderator.js
+++ b/src/managers/message-moderator.js
@@ -11,7 +11,6 @@ const DiscordUtils = require('../utils/discord-utils');
 
 const ArrayArgScanner = require('../arg_scanners/array-arg-scanner');
 
-const BotTable = require('../mongo_classes/bot-table');
 const ServerSettingsTable = require('../mongo_classes/server-settings-table');
 
 /**
@@ -28,21 +27,13 @@ class MessageModerator {
   }
 
   /**
-   * Sets the Discord client for the instance.
-   * @param {Client} client the Dicord client
-   */
-  setDiscordClient(client) {
-    this.discordClient = client;
-  }
-
-  /**
    * Premoderates incoming message (e.g. replaces bad words etc.)
    * @param  {BaseMessage}  message the Discordmessage
    * @return {Promise}                 nothing
    */
   async premoderateDiscordMessage(message) {
     const censoringEnabled = await this.context.dbManager.getSetting(
-      BotTable.DISCORD_SOURCE,
+      message.source.name,
       message.teamId,
       ServerSettingsTable.SERVER_SETTINGS.censoring.name,
       OhUtils.OFF
@@ -50,7 +41,7 @@ class MessageModerator {
 
     if (censoringEnabled === OhUtils.ON) {
       const badWordsString = await this.context.dbManager.getSetting(
-        BotTable.DISCORD_SOURCE,
+        message.source.name,
         message.teamId,
         ServerSettingsTable.SERVER_SETTINGS.badwords.name,
         ''

--- a/src/managers/message-moderator.js
+++ b/src/managers/message-moderator.js
@@ -67,14 +67,11 @@ class MessageModerator {
         }
 
         if (content !== message.content) {
-          await DiscordUtils.sendToTextChannel(
-            message.originalMessage.channel,
-            this.context.langManager.getString(
-              'moderator_censored_message',
-              DiscordUtils.makeUserMention(message.originalMessage.member.id),
-              content
-            )
-          );
+          await message.reply(this.context.langManager.getString(
+            'moderator_censored_message',
+            DiscordUtils.makeUserMention(message.originalMessage.member.id),
+            content
+          ));
           await message.originalMessage.delete();
         }
       }

--- a/src/managers/permissions-manager.js
+++ b/src/managers/permissions-manager.js
@@ -14,8 +14,6 @@ const BotPublicError = require('../utils/bot-public-error');
 const DiscordChannelsArg = require('../command_meta/discord-channels-arg');
 const DiscordSubjectsArg = require('../command_meta/discord-subjects-arg');
 
-const BotTable = require('../mongo_classes/bot-table');
-
 const DefinedPermissions = Object.freeze({
   remind: new MultiLangValue('remind', 'permission_type_remind'),
   role: new MultiLangValue('role', 'permission_type_role')

--- a/src/managers/permissions-manager.js
+++ b/src/managers/permissions-manager.js
@@ -306,20 +306,20 @@ class PermissionsManager {
    * Throws public error if the permissions are not found.
    * @throws {BotPublicError}
    * @param  {Client}          discordClient  the Discord client
-   * @param  {Message}         discordMessage the command's message
+   * @param  {BaseMessage}         message the command's message
    * @param  {DiscordCommand}  command        the command instance
    * @return {Promise}                        nothing
    */
-  async checkDiscordPermissions(discordClient, discordMessage, command) {
+  async checkDiscordPermissions(discordClient, message, command) {
     const requiredDiscordPermissions = command.constructor.getRequiredDiscordPermissions();
 
     for (const permission of requiredDiscordPermissions) {
-      if (!discordMessage.member.permissionsIn(discordMessage.channel).has(permission)) {
+      if (!message.originalMessage.member.permissionsIn(message.originalMessage.channel).has(permission)) {
         this.context.log.w(
           'Attempt to use command ' +
             command.constructor.getCommandInterfaceName() +
             ' by user ' +
-            discordMessage.member.id
+          message.originalMessage.member.id
         );
         throw new BotPublicError(command.langManager.getString('permission_missing_discord', permission));
       }
@@ -334,12 +334,12 @@ class PermissionsManager {
    * Throws public error if the permissions are not found.
    * @throws {BotPublicError}
    * @param  {Client}          discordClient  the Discord client
-   * @param  {Message}         discordMessage the command's message
+   * @param  {BaseMessage}         message the command's message
    * @param  {DiscordCommand}  command        the command instance
    * @return {Promise}                        nothing
    */
-  async checkDiscordCommandPermissions(discordClient, discordMessage, command) {
-    const rolesArray = discordMessage.member.roles.cache.array();
+  async checkDiscordCommandPermissions(discordClient, message, command) {
+    const rolesArray = message.originalMessage.member.roles.cache.array();
     const roleIds = [];
     for (const role of rolesArray) {
       roleIds.push(role.id);
@@ -347,21 +347,21 @@ class PermissionsManager {
 
     if (
       this.context.prefsManager.bypass_bot_permissions_for_discord_admins !== 'true' ||
-      !discordMessage.member.permissionsIn(discordMessage.channel).has(DiscordPermissions.ADMINISTRATOR)
+      !message.originalMessage.member.permissionsIn(message.originalMessage.channel).has(DiscordPermissions.ADMINISTRATOR)
     ) {
-      await this.checkBotPermissions(discordMessage.member.id, roleIds, command, BotTable.DISCORD_SOURCE);
+      await this.checkBotPermissions(message.originalMessage.member.id, roleIds, command, BotTable.DISCORD_SOURCE);
     }
 
-    await this.checkDiscordPermissions(discordClient, discordMessage, command);
+    await this.checkDiscordPermissions(discordClient, message, command);
   }
 
   /**
    * Checks if the author of the Discord message is admin on the server.
-   * @param  {Message}  discordMessage the message
+   * @param  {BaseMessage}  message the message
    * @return {Boolean}                 true if admin, false otherwise
    */
-  isAuthorAdmin(discordMessage) {
-    return discordMessage.member.permissionsIn(discordMessage.channel).has(DiscordPermissions.ADMINISTRATOR);
+  isAuthorAdmin(message) {
+    return message.originalMessage.member.permissionsIn(message.originalMessage.channel).has(DiscordPermissions.ADMINISTRATOR);
   }
 }
 

--- a/src/managers/permissions-manager.js
+++ b/src/managers/permissions-manager.js
@@ -349,7 +349,7 @@ class PermissionsManager {
       this.context.prefsManager.bypass_bot_permissions_for_discord_admins !== 'true' ||
       !message.originalMessage.member.permissionsIn(message.originalMessage.channel).has(DiscordPermissions.ADMINISTRATOR)
     ) {
-      await this.checkBotPermissions(message.originalMessage.member.id, roleIds, command, BotTable.DISCORD_SOURCE);
+      await this.checkBotPermissions(message.originalMessage.member.id, roleIds, command, message.source.name);
     }
 
     await this.checkDiscordPermissions(discordClient, message, command);

--- a/src/managers/permissions-manager.js
+++ b/src/managers/permissions-manager.js
@@ -154,115 +154,118 @@ class PermissionsManager {
   async checkBotPermissions(commandUserId, roleIds, command, source) {
     const permissionFilters = command.constructor.getRequiredBotPermissions();
 
-    const permissionResults = [];
-    for (const permissionFilter of permissionFilters) {
-      const andArray = [];
+    const permissionResults = permissionFilters.map(permissionFilter => {
+      const query = this.buildPermissionQuery(source, command, commandUserId, roleIds, permissionFilter);
+      return this.context.dbManager.getRows(this.context.dbManager.permissionsTable, query).then(permissions => {
+        this.verifyPermissions(permissionFilters, permissions, command);
+      });
+    });
+    await Promise.all(permissionResults);
+  }
 
-      andArray.push({ source });
-      andArray.push({ orgId: command.orgId });
+  buildPermissionQuery(source, command, commandUserId, roleIds, permissionFilter) {
+    const andArray = [];
 
-      const userIdQuery = { $and: [{ subjectType: SubjectTypes.user.name }, { subjectId: commandUserId }] };
+    andArray.push({ source });
+    andArray.push({ orgId: command.orgId });
 
-      const userRolesArrayQuery = [];
-      for (const roleId of roleIds) {
-        userRolesArrayQuery.push({ subjectId: roleId });
-      }
+    const userIdQuery = { $and: [{ subjectType: SubjectTypes.user.name }, { subjectId: commandUserId }] };
 
-      const userRolesQuery = { $and: [{ subjectType: SubjectTypes.role.name }, { $or: userRolesArrayQuery }] };
+    const userRolesArrayQuery = [];
+    for (const roleId of roleIds) {
+      userRolesArrayQuery.push({ subjectId: roleId });
+    }
 
-      const idQuery = { $or: [userIdQuery, userRolesQuery] };
-      andArray.push(idQuery);
+    const userRolesQuery = { $and: [{ subjectType: SubjectTypes.role.name }, { $or: userRolesArrayQuery }] };
 
-      andArray.push({ permissionType: permissionFilter.permissionName });
+    const idQuery = { $or: [userIdQuery, userRolesQuery] };
+    andArray.push(idQuery);
 
-      const filtersArrayQuery = [];
-      const filtersFields = permissionFilter.filterFields;
-      for (const filtersField of filtersFields) {
-        const anyValueObject = {};
-        anyValueObject['filter.' + filtersField.filterFieldName] = OhUtils.ANY_VALUE;
-        const orFilterArray = [anyValueObject];
+    andArray.push({ permissionType: permissionFilter.permissionName });
 
-        if (command[filtersField.argName] instanceof DiscordChannelsArg) {
-          const channelsFilter = command[filtersField.argName].channels;
-          for (const channel of channelsFilter) {
-            const particularValueObject = {};
-            particularValueObject['filter.' + filtersField.filterFieldName] = channel;
-            orFilterArray.push(particularValueObject);
-          }
-        } else if (command[filtersField.argName] instanceof DiscordSubjectsArg) {
-          const subjectIdsFilter = command[filtersField.argName].subjectIds;
-          for (const subjectId of subjectIdsFilter) {
-            const particularValueObject = {};
-            particularValueObject['filter.' + filtersField.filterFieldName] = subjectId;
-            orFilterArray.push(particularValueObject);
-          }
+    const filtersArrayQuery = [];
+    const filtersFields = permissionFilter.filterFields;
+    for (const filtersField of filtersFields) {
+      const anyValueObject = {};
+      anyValueObject['filter.' + filtersField.filterFieldName] = OhUtils.ANY_VALUE;
+      const orFilterArray = [anyValueObject];
 
-          const subjectRolesFilter = command[filtersField.argName].subjectRoles;
-          for (const subjectRole of subjectRolesFilter) {
-            const particularValueObject = {};
-            particularValueObject['filter.' + filtersField.filterFieldName] = subjectRole;
-            orFilterArray.push(particularValueObject);
-          }
-        } else {
+      if (command[filtersField.argName] instanceof DiscordChannelsArg) {
+        const channelsFilter = command[filtersField.argName].channels;
+        for (const channel of channelsFilter) {
           const particularValueObject = {};
-          particularValueObject['filter.' + filtersField.filterFieldName] = command[filtersField.argName];
+          particularValueObject['filter.' + filtersField.filterFieldName] = channel;
+          orFilterArray.push(particularValueObject);
+        }
+      } else if (command[filtersField.argName] instanceof DiscordSubjectsArg) {
+        const subjectIdsFilter = command[filtersField.argName].subjectIds;
+        for (const subjectId of subjectIdsFilter) {
+          const particularValueObject = {};
+          particularValueObject['filter.' + filtersField.filterFieldName] = subjectId;
           orFilterArray.push(particularValueObject);
         }
 
-        filtersArrayQuery.push({ $or: orFilterArray });
+        const subjectRolesFilter = command[filtersField.argName].subjectRoles;
+        for (const subjectRole of subjectRolesFilter) {
+          const particularValueObject = {};
+          particularValueObject['filter.' + filtersField.filterFieldName] = subjectRole;
+          orFilterArray.push(particularValueObject);
+        }
+      } else {
+        const particularValueObject = {};
+        particularValueObject['filter.' + filtersField.filterFieldName] = command[filtersField.argName];
+        orFilterArray.push(particularValueObject);
       }
 
-      andArray.push({ $and: filtersArrayQuery });
-
-      const query = { $and: andArray };
-
-      permissionResults.push(
-        this.context.dbManager.getRows(this.context.dbManager.permissionsTable, query).then(permissions => {
-          for (const permissionFilter of permissionFilters) {
-            if (permissions === null || permissions.length === 0) {
-              this.context.log.f('Required permissions not found for: ' + permissionFilter.permissionName);
-              throw new BotPublicError(
-                command.langManager.getString(
-                  'permission_missing_bot',
-                  command.langManager.getString(DefinedPermissions[permissionFilter.permissionName].textId)
-                )
-              );
-            }
-
-            const filtersFields = permissionFilter.filterFields;
-
-            for (const filterField of filtersFields) {
-              if (command[filterField.argName] instanceof DiscordChannelsArg) {
-                this.checkDiscordEntityFilter(
-                  permissionFilter.permissionName,
-                  filterField.filterFieldName,
-                  permissions,
-                  command[filterField.argName].channels,
-                  command.langManager
-                );
-              } else if (command[filterField.argName] instanceof DiscordSubjectsArg) {
-                this.checkDiscordEntityFilter(
-                  permissionFilter.permissionName,
-                  filterField.filterFieldName,
-                  permissions,
-                  command[filterField.argName].subjectIds,
-                  command.langManager
-                );
-                this.checkDiscordEntityFilter(
-                  permissionFilter.permissionName,
-                  filterField.filterFieldName,
-                  permissions,
-                  command[filterField.argName].subjectRoles,
-                  command.langManager
-                );
-              }
-            }
-          }
-        })
-      );
+      filtersArrayQuery.push({ $or: orFilterArray });
     }
 
-    await Promise.all(permissionResults);
+    andArray.push({ $and: filtersArrayQuery });
+
+    return { $and: andArray };
+  }
+
+  verifyPermissions(permissionFilters, permissions, command) {
+    for (const permissionFilter of permissionFilters) {
+      if (permissions === null || permissions.length === 0) {
+        this.context.log.f('Required permissions not found for: ' + permissionFilter.permissionName);
+        throw new BotPublicError(
+          command.langManager.getString(
+            'permission_missing_bot',
+            command.langManager.getString(DefinedPermissions[permissionFilter.permissionName].textId)
+          )
+        );
+      }
+
+      const filtersFields = permissionFilter.filterFields;
+
+      for (const filterField of filtersFields) {
+        if (command[filterField.argName] instanceof DiscordChannelsArg) {
+          this.checkDiscordEntityFilter(
+            permissionFilter.permissionName,
+            filterField.filterFieldName,
+            permissions,
+            command[filterField.argName].channels,
+            command.langManager
+          );
+        } else if (command[filterField.argName] instanceof DiscordSubjectsArg) {
+          this.checkDiscordEntityFilter(
+            permissionFilter.permissionName,
+            filterField.filterFieldName,
+            permissions,
+            command[filterField.argName].subjectIds,
+            command.langManager
+          );
+          this.checkDiscordEntityFilter(
+            permissionFilter.permissionName,
+            filterField.filterFieldName,
+            permissions,
+            command[filterField.argName].subjectRoles,
+            command.langManager
+          );
+        }
+      }
+    }
   }
 
   /**
@@ -278,14 +281,11 @@ class PermissionsManager {
    */
   checkDiscordEntityFilter(permissionName, filterFieldName, permissionRows, entitiesFilter, langManager) {
     for (const entityFilter of entitiesFilter) {
-      let found = false;
-      for (const permissionRow of permissionRows) {
-        const filterValue = permissionRow.filter[filterFieldName];
-        if (filterValue === entityFilter || filterValue === OhUtils.ANY_VALUE) {
-          found = true;
-          break;
-        }
-      }
+
+      const found = permissionRows.some(row => {
+        const filterValue = row.filter[filterFieldName];
+        return filterValue === entityFilter || filterValue === OhUtils.ANY_VALUE;
+      });
 
       if (!found) {
         this.context.log.f('Required permissions not found for a particular entity: ' + entityFilter);
@@ -303,20 +303,19 @@ class PermissionsManager {
    * Checks if the author of the Discord message has necessary permissions in the channel.
    * Throws public error if the permissions are not found.
    * @throws {BotPublicError}
-   * @param  {Client}          discordClient  the Discord client
    * @param  {BaseMessage}         message the command's message
    * @param  {DiscordCommand}  command        the command instance
    * @return {Promise}                        nothing
    */
-  async checkDiscordPermissions(discordClient, message, command) {
+  async checkDiscordPermissions(message, command) {
     const requiredDiscordPermissions = command.constructor.getRequiredDiscordPermissions();
 
     for (const permission of requiredDiscordPermissions) {
       if (!message.originalMessage.member.permissionsIn(message.originalMessage.channel).has(permission)) {
         this.context.log.w(
           'Attempt to use command ' +
-            command.constructor.getCommandInterfaceName() +
-            ' by user ' +
+          command.constructor.getCommandInterfaceName() +
+          ' by user ' +
           message.originalMessage.member.id
         );
         throw new BotPublicError(command.langManager.getString('permission_missing_discord', permission));
@@ -331,17 +330,12 @@ class PermissionsManager {
    * the bypass is enabled in Bot's preferences (typically should be "true" for all non-dev Bot's instances).
    * Throws public error if the permissions are not found.
    * @throws {BotPublicError}
-   * @param  {Client}          discordClient  the Discord client
    * @param  {BaseMessage}         message the command's message
    * @param  {DiscordCommand}  command        the command instance
    * @return {Promise}                        nothing
    */
-  async checkDiscordCommandPermissions(discordClient, message, command) {
-    const rolesArray = message.originalMessage.member.roles.cache.array();
-    const roleIds = [];
-    for (const role of rolesArray) {
-      roleIds.push(role.id);
-    }
+  async checkDiscordCommandPermissions(message, command) {
+    const roleIds = message.originalMessage.member.roles.cache.array().map(r => r.id);
 
     if (
       this.context.prefsManager.bypass_bot_permissions_for_discord_admins !== 'true' ||
@@ -350,7 +344,7 @@ class PermissionsManager {
       await this.checkBotPermissions(message.originalMessage.member.id, roleIds, command, message.source.name);
     }
 
-    await this.checkDiscordPermissions(discordClient, message, command);
+    await this.checkDiscordPermissions(message, command);
   }
 
   /**


### PR DESCRIPTION
Goal: 
To make commands reusable from the different sources (e.g. slack) we need to decouple command and command source and source-specific messages.


Partially tested (!ping & !help works ;)

**Semantic versioning classification:**
- [x] This PR changes the core classes (e.g. base classes like Command, BotTable etc.)

