### PR TITLE
Add context at express instance

### DIFF
--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -1,21 +1,19 @@
-const path = require('path');
-const prefsPath = path.join(__dirname, '../../../', 'preferences.txt');
-const PrefsManager = require('../../managers/prefs-manager');
-const prefsManager = new PrefsManager(prefsPath);
-
-prefsManager.readPrefs();
-
 const makeRedirect = async (req, res) => {
-  try {
-    res.redirect(
-      `https://discord.com/api/oauth2/authorize?client_id=${prefsManager.app_id}&redirect_uri=${prefsManager.redirect_url}}&response_type=code&scope=identify`
-    );
-    return;
-  } catch (e) {
-    res.status(401).send('error: ' + e);
-  }
-};
-
-module.exports = {
-  makeRedirect
-};
+	const context = req.app.get('context');
+	const appId = context.prefsManager.app_id;
+	const redirectUrl = context.prefsManager.redirect_url;
+  
+	try {
+	  res.redirect(
+		`https://discord.com/api/oauth2/authorize?client_id=${appId}&redirect_uri=${redirectUrl}}&response_type=code&scope=identify`
+	  );
+	  return;
+	} catch (e) {
+	  res.status(401).send('error: ' + e);
+	}
+  };
+  
+  module.exports = {
+	makeRedirect
+  };
+  

--- a/src/api/init-api.js
+++ b/src/api/init-api.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const app = express();
 const auth = require('./routes/auth');
+const roles = require('./routes/roles');
 const cors = require('cors');
 
 function initApi(c) {
@@ -9,7 +10,10 @@ function initApi(c) {
     console.log('Api-Server is running on port: ' + c.prefsManager.server_port);
   });
 
+  app.set('context', c);
+
   app.use('/auth', auth);
+  app.use('/roles', roles);
 }
 
 module.exports = {


### PR DESCRIPTION
After this merge, in api-controllers (src/api/contorollers) or wherever we need use express instance - we can easily use it by calling express req/res arguments.

Example:

```

const makeRedirect = async (req, res) => {
  const context = req.app.get('context');
  const appId = context.prefsManager.app_id;
  const redirectUrl = context.prefsManager.redirect_url;

  try {
    res.redirect(
    ...
```

